### PR TITLE
Add wait_for_navigation tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { TauriDriver } from './tauri-driver.js';
 import { launchApp, closeApp, getAppState } from './tools/launch.js';
 import { captureScreenshot } from './tools/screenshot.js';
 import { clickElement, typeText, waitForElement, getElementText } from './tools/interact.js';
-import { executeTauriCommand } from './tools/state.js';
+import { executeTauriCommand, executeScript, getPageTitle, getPageUrl } from './tools/state.js';
 import type { TauriAutomationConfig } from './types.js';
 
 // Parse config from environment variables
@@ -189,6 +189,41 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: 'execute_script',
+        description: 'Execute arbitrary JavaScript in the application context and return the result',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            script: {
+              type: 'string',
+              description: 'JavaScript code to execute. Use "return" to get a value back.',
+            },
+            args: {
+              type: 'array',
+              description: 'Optional arguments accessible as arguments[0], arguments[1], etc.',
+              items: {},
+            },
+          },
+          required: ['script'],
+        },
+      },
+      {
+        name: 'get_page_title',
+        description: 'Get the current page title of the application',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      {
+        name: 'get_page_url',
+        description: 'Get the current page URL of the application',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      {
         name: 'get_app_state',
         description: 'Get the current state of the application, including whether it\'s running, session info, and page details',
         inputSchema: {
@@ -309,6 +344,42 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'execute_tauri_command': {
         const result = await executeTauriCommand(driver, args as any);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'execute_script': {
+        const result = await executeScript(driver, args as any);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'get_page_title': {
+        const result = await getPageTitle(driver);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'get_page_url': {
+        const result = await getPageUrl(driver);
         return {
           content: [
             {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
 import { TauriDriver } from './tauri-driver.js';
 import { launchApp, closeApp, getAppState } from './tools/launch.js';
 import { captureScreenshot } from './tools/screenshot.js';
-import { clickElement, typeText, waitForElement, getElementText } from './tools/interact.js';
+import { clickElement, typeText, waitForElement, waitForNavigation, getElementText } from './tools/interact.js';
 import { executeTauriCommand, executeScript, getPageTitle, getPageUrl } from './tools/state.js';
 import type { TauriAutomationConfig } from './types.js';
 
@@ -153,6 +153,24 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
           },
           required: ['selector'],
+        },
+      },
+      {
+        name: 'wait_for_navigation',
+        description: 'Wait for a page navigation to complete. Can wait for any URL change or for the URL to contain a specific substring.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            urlContains: {
+              type: 'string',
+              description: 'Optional substring the URL must contain. If omitted, waits for any URL change from the current URL.',
+            },
+            timeout: {
+              type: 'number',
+              description: 'Timeout in milliseconds. Default: 5000',
+              default: 5000,
+            },
+          },
         },
       },
       {
@@ -320,6 +338,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'wait_for_element': {
         const result = await waitForElement(driver, args as any);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'wait_for_navigation': {
+        const result = await waitForNavigation(driver, args as any);
         return {
           content: [
             {

--- a/src/tauri-driver.ts
+++ b/src/tauri-driver.ts
@@ -173,16 +173,21 @@ export class TauriDriver {
     await this.appState.browser!.waitUntil(
       async () => {
         const currentUrl = await this.appState.browser!.getUrl();
+        // Always require URL to change from starting URL
+        if (currentUrl === startUrl) {
+          return false;
+        }
+        // If urlContains specified, also check that the new URL matches
         if (opts.urlContains) {
           return currentUrl.includes(opts.urlContains);
         }
-        // If no pattern specified, wait for any URL change
-        return currentUrl !== startUrl;
+        // Otherwise, any URL change is sufficient
+        return true;
       },
       {
         timeout: timeoutMs,
         timeoutMsg: opts.urlContains
-          ? `URL did not contain "${opts.urlContains}" within ${timeoutMs}ms`
+          ? `URL did not change to one containing "${opts.urlContains}" within ${timeoutMs}ms`
           : `URL did not change from "${startUrl}" within ${timeoutMs}ms`,
         interval: 200,
       }

--- a/src/tauri-driver.ts
+++ b/src/tauri-driver.ts
@@ -162,6 +162,36 @@ export class TauriDriver {
   }
 
   /**
+   * Wait for navigation (URL change or match a pattern)
+   */
+  async waitForNavigation(opts: { urlContains?: string; timeout?: number } = {}): Promise<string> {
+    this.ensureAppRunning();
+
+    const timeoutMs = opts.timeout || this.config.defaultTimeout;
+    const startUrl = await this.appState.browser!.getUrl();
+
+    await this.appState.browser!.waitUntil(
+      async () => {
+        const currentUrl = await this.appState.browser!.getUrl();
+        if (opts.urlContains) {
+          return currentUrl.includes(opts.urlContains);
+        }
+        // If no pattern specified, wait for any URL change
+        return currentUrl !== startUrl;
+      },
+      {
+        timeout: timeoutMs,
+        timeoutMsg: opts.urlContains
+          ? `URL did not contain "${opts.urlContains}" within ${timeoutMs}ms`
+          : `URL did not change from "${startUrl}" within ${timeoutMs}ms`,
+        interval: 200,
+      }
+    );
+
+    return await this.appState.browser!.getUrl();
+  }
+
+  /**
    * Get text content of an element
    */
   async getElementText(selector: string): Promise<string> {

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -3,7 +3,7 @@
  */
 
 import type { TauriDriver } from '../tauri-driver.js';
-import type { ElementSelector, TypeTextParams, WaitForElementParams, ToolResponse } from '../types.js';
+import type { ElementSelector, TypeTextParams, WaitForElementParams, WaitForNavigationParams, ToolResponse } from '../types.js';
 
 /**
  * Click an element by CSS selector
@@ -67,6 +67,33 @@ export async function waitForElement(
       success: true,
       data: {
         message: `Element found: ${params.selector}`,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Wait for navigation (URL change or URL matching a pattern)
+ */
+export async function waitForNavigation(
+  driver: TauriDriver,
+  params: WaitForNavigationParams = {}
+): Promise<ToolResponse<{ url: string; message: string }>> {
+  try {
+    const url = await driver.waitForNavigation(params);
+
+    return {
+      success: true,
+      data: {
+        url,
+        message: params.urlContains
+          ? `Navigation complete, URL contains "${params.urlContains}": ${url}`
+          : `Navigation complete, URL changed to: ${url}`,
       },
     };
   } catch (error) {

--- a/src/tools/state.ts
+++ b/src/tools/state.ts
@@ -3,7 +3,7 @@
  */
 
 import type { TauriDriver } from '../tauri-driver.js';
-import type { ExecuteTauriCommandParams, ToolResponse } from '../types.js';
+import type { ExecuteTauriCommandParams, ExecuteScriptParams, ToolResponse } from '../types.js';
 
 /**
  * Execute a Tauri IPC command
@@ -19,6 +19,76 @@ export async function executeTauriCommand(
       success: true,
       data: {
         result,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Execute arbitrary JavaScript in the application context
+ */
+export async function executeScript(
+  driver: TauriDriver,
+  params: ExecuteScriptParams
+): Promise<ToolResponse<{ result: unknown }>> {
+  try {
+    const result = await driver.executeScript(params.script, ...(params.args || []));
+
+    return {
+      success: true,
+      data: {
+        result,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Get the current page title
+ */
+export async function getPageTitle(
+  driver: TauriDriver
+): Promise<ToolResponse<{ title: string }>> {
+  try {
+    const title = await driver.getPageTitle();
+
+    return {
+      success: true,
+      data: {
+        title,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Get the current page URL
+ */
+export async function getPageUrl(
+  driver: TauriDriver
+): Promise<ToolResponse<{ url: string }>> {
+  try {
+    const url = await driver.getPageUrl();
+
+    return {
+      success: true,
+      data: {
+        url,
       },
     };
   } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,16 @@ export interface WaitForElementParams {
 }
 
 /**
+ * Wait for navigation parameters
+ */
+export interface WaitForNavigationParams {
+  /** Optional substring the URL must contain. If omitted, waits for any URL change. */
+  urlContains?: string;
+  /** Timeout in milliseconds. Default: 5000 */
+  timeout?: number;
+}
+
+/**
  * Execute Tauri command parameters
  */
 export interface ExecuteTauriCommandParams {

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,16 @@ export interface ExecuteTauriCommandParams {
 }
 
 /**
+ * Execute script parameters
+ */
+export interface ExecuteScriptParams {
+  /** JavaScript code to execute */
+  script: string;
+  /** Optional arguments accessible as arguments[0], arguments[1], etc. */
+  args?: unknown[];
+}
+
+/**
  * Tool response wrapper
  */
 export interface ToolResponse<T = unknown> {


### PR DESCRIPTION
## Summary
- New `wait_for_navigation` MCP tool for waiting on page navigation to complete
- Two modes: wait for any URL change (no params) or wait for URL to contain a substring (`urlContains`)
- Configurable `timeout` parameter (default: 5000ms)
- Returns the final URL on success
- Useful after clicking links or submitting forms to ensure the resulting page has loaded

## Test plan
- [ ] Verify `wait_for_navigation` with no params waits for any URL change
- [ ] Verify `wait_for_navigation` with `urlContains` waits for matching URL
- [ ] Verify timeout fires and returns error when navigation doesn't happen
- [ ] Verify returned URL is the final URL after navigation