### PR TITLE
feat: right/middle mouse button for click_element (enables context menus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Launch my calculator app at ~/projects/calculator/target/debug/calculator and te
 | `launch_app` | Launch your Tauri application |
 | `close_app` | Close the running application |
 | `capture_screenshot` | Take a screenshot (returns base64 PNG) |
-| `click_element` | Click UI elements by CSS selector |
+| `click_element` | Click UI elements by CSS selector (`button: "left" \| "right" \| "middle"`, default `left`; use `right` to open context menus) |
 | `type_text` | Type into input fields |
 | `wait_for_element` | Wait for elements to appear |
 | `get_element_text` | Read text from elements |

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,13 +101,18 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'click_element',
-        description: 'Click a UI element identified by a CSS selector',
+        description: 'Click a UI element identified by a CSS selector. Use button:"right" to open context menus.',
         inputSchema: {
           type: 'object',
           properties: {
             selector: {
               type: 'string',
               description: 'CSS selector to identify the element to click (e.g., "#button-id", ".button-class", "button[name=submit]")',
+            },
+            button: {
+              type: 'string',
+              enum: ['left', 'right', 'middle'],
+              description: 'Mouse button to click with. Defaults to "left". Use "right" for a context-menu (right) click.',
             },
           },
           required: ['selector'],

--- a/src/tauri-driver.ts
+++ b/src/tauri-driver.ts
@@ -115,9 +115,14 @@ export class TauriDriver {
   }
 
   /**
-   * Click an element by CSS selector
+   * Click an element by CSS selector.
+   * `button` selects the mouse button ('left' | 'right' | 'middle'); right/middle
+   * go through the WebDriver Actions API so context menus fire.
    */
-  async clickElement(selector: string): Promise<void> {
+  async clickElement(
+    selector: string,
+    button: 'left' | 'right' | 'middle' = 'left'
+  ): Promise<void> {
     this.ensureAppRunning();
 
     const element = await this.appState.browser!.$(selector);
@@ -125,7 +130,7 @@ export class TauriDriver {
       throw new Error(`Element not found: ${selector}`);
     }
 
-    await element.click();
+    await element.click({ button });
   }
 
   /**

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -13,12 +13,13 @@ export async function clickElement(
   params: ElementSelector
 ): Promise<ToolResponse<{ message: string }>> {
   try {
-    await driver.clickElement(params.selector);
+    const button = params.button ?? 'left';
+    await driver.clickElement(params.selector, button);
 
     return {
       success: true,
       data: {
-        message: `Clicked element: ${params.selector}`,
+        message: `${button === 'left' ? 'Clicked' : `${button}-clicked`} element: ${params.selector}`,
       },
     };
   } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,8 @@ export interface ScreenshotParams {
 export interface ElementSelector {
   /** CSS selector string */
   selector: string;
+  /** Mouse button to click with. Defaults to 'left'. */
+  button?: 'left' | 'right' | 'middle';
 }
 
 /**


### PR DESCRIPTION
## What

Adds an optional `button` argument to the `click_element` tool: `"left" | "right" | "middle"` (default `"left"`). Right/middle clicks go through the WebDriver Actions API via `element.click({ button })`.

## Why

There was previously no way to trigger a right-click, so an agent couldn't open context menus in the app under test. This is a small, backward-compatible addition — omitting `button` behaves exactly as before.

## Changes

- `click_element` schema gains a `button` enum — `src/index.ts`
- `clickElement` threads the button through to `element.click({ button })` — `src/tauri-driver.ts`, `src/tools/interact.ts`, `src/types.ts`
- README tool table updated

## Testing

Built and run against a real Tauri v2 app via `tauri-driver` on Linux/WebKitGTK:

- `tools/list` exposes the new `button` parameter.
- `click_element { selector, button: "right" }` issues a W3C Actions context-click (pointer button `2`) and fires the page's `contextmenu` handler — the app's context menu opens, confirmed via `capture_screenshot`.

Backward compatible: existing `click_element` calls without `button` are unchanged.
